### PR TITLE
Include devcontainer image build environment infos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For now, the only supported tooling setup is to use the provided VSCode devconta
 - Install VSCode
   - Install the [Remote Development extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
   - You do *not* need to install the Haskell extension
-- Get the docker image (for now, we need to build this with Nix)
+- Get the docker image (for now, we need to build this with Nix, which was tested with Ubuntu and is currently not building on macOS or NixOS)
   - Clone https://github.com/input-output-hk/plutus 
   - Set up your machine to build things with Nix, following the Plutus README (make sure to set up the binary cache!)
   - Build and load the docker container: `docker load < $(nix-build default.nix -A devcontainer)`


### PR DESCRIPTION
Hi there,

at the moment I'm not able to build the `devcontainer` image on macOS nor NixOS. I've managed to build the image on Ubuntu 20.04 and included some infos into the Readme.

On macOS I do get the following error:

```sh
> docker load < $(nix-build default.nix -A devcontainer)
error: assertion (stdenv).isLinux failed at /nix/store/qrbp0y6mfscqhfhzivnhc91hvby45nv7-nixpkgs-src/pkgs/os-specific/linux/kernel/generic.nix:67:1
...
```

I've also tried to build the image on macOS within a NixOS docker session, as well as on a NixOS AWS EC2 instance and got similar errors on both session:

```sh
...
building '/nix/store/zgk2psbvq447k3g1jsp5884y337v2x94-vm-run.drv'...
copying path '/nix/store/p6fjyny98if8dawzrs4irym0c7cn016x-ghc-shell-for-packages-ghc-8.10.4.20210212-env' from 'https://hydra.iohk.io'...
building '/nix/store/9rq5ybd32yppny3id8w1r0b66zg1qy4n-wrapped.drv'...
unpacking sources
unpacking source archive /nix/store/aj62vviwv7ck1zknfw2qznl47x0h8rq8-root
source root is root
patching sources
configuring
no configure script, doing nothing
building
no Makefile, doing nothing
installing
post-installation fixup
chmod: changing permissions of '/nix/store/y502vpypwa850q4klfp9799y7z2rb79n-wrapped': Operation not permitted
chmod: changing permissions of '/nix/store/y502vpypwa850q4klfp9799y7z2rb79n-wrapped/etc': Operation not permitted
chmod: changing permissions of '/nix/store/y502vpypwa850q4klfp9799y7z2rb79n-wrapped/etc/skel': Operation not permitted
chmod: changing permissions of '/nix/store/y502vpypwa850q4klfp9799y7z2rb79n-wrapped/etc/skel/.bashrc': Operation not permitted
builder for '/nix/store/9rq5ybd32yppny3id8w1r0b66zg1qy4n-wrapped.drv' failed with exit code 1
cannot build derivation '/nix/store/4asn46f2dkgrn60d1jb7yw3rbnfqby5f-docker-layer-plutus-devcontainer.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/9p0bmasgs2a3xm5hghb1gmgglpz2any6-docker-layer-plutus-devcontainer.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/g7v297jww1ilv6r1wzj629w7f62760db-docker-image-plutus-devcontainer.tar.gz.drv': 1 dependencies couldn't be built
error: build of '/nix/store/g7v297jww1ilv6r1wzj629w7f62760db-docker-image-plutus-devcontainer.tar.gz.drv' failed
```
