### PR TITLE
Sync up guess endpoint to match plutus game contract

### DIFF
--- a/examples/src/Plutus/Contracts/Game.hs
+++ b/examples/src/Plutus/Contracts/Game.hs
@@ -146,12 +146,12 @@ lock = do
 
 guess :: (AsContractError e) => Contract () GameSchema e ()
 guess = do
-    -- Wait for script to have a UTxO of a least 1 lovelace
-    logInfo @Prelude.String "Waiting for script to have a UTxO of at least 1 lovelace"
-    utxos <- fundsAtAddressGeq gameAddress (Ada.lovelaceValueOf 1)
     -- Wait for a call on the guess endpoint
     logInfo @Prelude.String "Waiting for guess endpoint..."
     GuessParams theGuess <- endpoint @"guess" @GuessParams
+    -- Wait for script to have a UTxO of a least 1 lovelace
+    logInfo @Prelude.String "Waiting for script to have a UTxO of at least 1 lovelace"
+    utxos <- fundsAtAddressGeq gameAddress (Ada.lovelaceValueOf 1)
 
     let redeemer = clearString theGuess
         tx       = collectFromScript utxos redeemer


### PR DESCRIPTION
Fixes issue reported on plutus https://github.com/input-output-hk/plutus/issues/3526 , but there may still be a change in behavior for awaiting on slots introduced by https://github.com/input-output-hk/plutus/pull/3342 that needs to be investigated further as the changes introduced didn't use to be required prior to it