### PR TITLE
An attempt to play better with haskell-language-server

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,2 +1,10 @@
 cradle:
   cabal:
+    - path: "./src"
+      component: "plutus-starter:lib:plutus-starter"
+    - path: "./examples/src"
+      component: "plutus-starter:lib:plutus-starter"
+    - path: "./examples/test"
+      component: "plutus-starter:test:plutus-example-projects-test"
+    - path: "./pab"
+      component: "plutus-starter:exe:plutus-starter-pab"

--- a/plutus-starter.cabal
+++ b/plutus-starter.cabal
@@ -21,7 +21,26 @@ maintainer:         Your email
 -- category:
 -- extra-source-files: CHANGELOG.md
 
+flag defer-plugin-errors
+    description:
+        Defer errors from the plugin, useful for things like Haddock that can't handle it.
+    default: False
+    manual: True
+
+common lang
+    default-language:   Haskell2010
+    ghc-options:
+      -Wall -Wnoncanonical-monad-instances
+      -Wincomplete-uni-patterns -Wincomplete-record-updates
+      -Wredundant-constraints -Widentities -rtsopts
+      -- See Plutus Tx readme
+      -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
+    -- See Plutus Tx readme
+    if flag(defer-plugin-errors)
+        ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
+
 library
+    import: lang
     exposed-modules:
       MyModule
       Plutus.Contracts.Game
@@ -37,23 +56,14 @@ library
       plutus-tx,
       plutus-ledger
     hs-source-dirs: src examples/src
-    default-language: Haskell2010
-    ghc-options:
-            -- See Plutus Tx readme
-            -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
 
 test-suite plutus-example-projects-test
+  import: lang
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   hs-source-dirs: examples/test
   other-modules:
     Spec.Game
-  default-language: Haskell2010
-  ghc-options: -Wall -Wnoncanonical-monad-instances
-              -Wincomplete-uni-patterns -Wincomplete-record-updates
-              -Wredundant-constraints -Widentities -rtsopts
-              -- See Plutus Tx readme
-              -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
   build-depends:
     plutus-tx -any,
     plutus-tx-plugin,
@@ -67,6 +77,7 @@ test-suite plutus-example-projects-test
     tasty-hedgehog >=0.2.0.0
 
 executable plutus-starter-pab
+  import: lang
   main-is: Main.hs
   hs-source-dirs: pab
   ghc-options:


### PR DESCRIPTION
by deferring plutus tx plugin errors.

I'm still not sure what exactly hls is doing that exhibits different behavior than `cabal build`, but I suspect that there might be some invoking of haddock which doesn't play well with the plugin

Fixes https://github.com/input-output-hk/plutus/issues/3454

![2021-07-29-151807_2484x2073_scrot](https://user-images.githubusercontent.com/817138/127553118-b7a37ac0-eed8-4b39-ba5d-ceed5f36638f.png)
