### PR TITLE
Enabling the endpoints of Game Contract for multiple HTTP calls

### DIFF
--- a/examples/src/Plutus/Contracts/Game.hs
+++ b/examples/src/Plutus/Contracts/Game.hs
@@ -163,7 +163,7 @@ secretWordValue o = do
 game :: AsContractError e => Contract () GameSchema e ()
 game = do
     logInfo @Haskell.String "Waiting for guess or lock endpoint..."
-    selectList [lock, guess]
+    selectList [lock, guess] >> game
 
 
 lockTrace :: Wallet -> Haskell.String -> EmulatorTrace ()


### PR DESCRIPTION
The Game endpoints `lock` and `guess` can be accessed only once via HTTP.
Calling the function `game` recursively after the selectList call.
This will enable the endpoints for infinite HTTP requests.