### PR TITLE
bump to version 1.0.9; example of costing scripts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Plutus Starter Project",
-    "image": "docker.io/inputoutput/plutus-starter-devcontainer:v1.0.8",
+    "image": "docker.io/inputoutput/plutus-starter-devcontainer:v1.0.9",
 
     "remoteUser": "plutus",
 

--- a/README.md
+++ b/README.md
@@ -97,19 +97,26 @@ The game has two players (wallets). One will initialise the contract and lock a 
 wallet will then make guesses. Supposing they guess correctly, they'll receive the funds that were
 locked; otherwise, they won't!
 
-1. Start the instances:
+
+1. Create wallets
+```
+export WALLET_ID_1=`curl -s -d '' http://localhost:9080/wallet/create | jq '.wiWallet.getWalletId'`
+export WALLET_ID_2=`curl -s -d '' http://localhost:9080/wallet/create | jq '.wiWallet.getWalletId'`
+```
+
+2. Start the instances:
 
 ```
 # Wallet 1
 curl -s -H "Content-Type: application/json" \
   --request POST \
-  --data '{"caID": "GameContract", "caWallet":{"getWallet": 1}}' \
+  --data '{"caID": "GameContract", "caWallet":{"getWalletId": '$WALLET_ID_1'}}' \
   http://localhost:9080/api/contract/activate | jq
 
 # Wallet 2
 curl -s -H "Content-Type: application/json" \
   --request POST \
-  --data '{"caID": "GameContract", "caWallet":{"getWallet": 2}}' \
+  --data '{"caID": "GameContract", "caWallet":{"getWalletId": '$WALLET_ID_2'}}' \
   http://localhost:9080/api/contract/activate | jq
 ```
 
@@ -117,7 +124,7 @@ From these two queries you will get back two contract instance IDs. These will b
 in the subsequent steps for running actions against. We can optionally take a look at the state
 of the contract with the `status` API:
 
-2. Get the status
+3. Get the status
 
 ```
 export INSTANCE_ID=...
@@ -127,7 +134,7 @@ curl -s http://localhost:9080/api/contract/instance/$INSTANCE_ID/status | jq
 This has a lot of information; and in particular we can see what endpoints are still available
 to call.
 
-3. Start the game by locking some value inside
+4. Start the game by locking some value inside
 
 Now, let's call the `lock` endpoint to start the game. In order to do so, we need to construct
 a JSON representation of the `LockParams` that the endpoint takes (look at `Game.hs`). The easiest
@@ -147,7 +154,7 @@ cabal repl
 Great! This is all we need to call the `lock` endpoint, so let's do that now with
 the instance from Wallet 1:
 
-4. Lock some value (Wallet 1)
+5. Lock some value (Wallet 1)
 
 ```
 export INSTANCE_ID=...
@@ -160,7 +167,7 @@ curl -H "Content-Type: application/json" \
 We can do likewise to work out what the JSON for `GuessParams` is, and then make a guess from
 Wallet 2:
 
-5. Make a guess (Wallet 2)
+6. Make a guess (Wallet 2)
 
 ```
 export INSTANCE_ID=...

--- a/cabal.project
+++ b/cabal.project
@@ -28,7 +28,7 @@ source-repository-package
     prettyprinter-configurable
     quickcheck-dynamic
     word-array
-  tag: plutus-starter-devcontainer/v1.0.8
+  tag: plutus-starter-devcontainer/v1.0.9
 
 
 -- The following sections are copied from the 'plutus' repository cabal.project at the revision
@@ -85,8 +85,7 @@ package cardano-api
 -- when decoding invalid (e.g. malicious) text literals.
 source-repository-package
   type: git
-  -- location: https://github.com/Quid2/flat.git
-  location: https://github.com/michaelpj/flat.git
+  location: https://github.com/Quid2/flat.git
   tag: ee59880f47ab835dbd73bea0847dab7869fc20d8
 
 -- Needs some patches, but upstream seems to be fairly dead (no activity in > 1 year)
@@ -108,7 +107,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: cb0f19c85e5bb5299839ad4ed66af6fa61322cc4
+  tag: 46502694f6a9f0498f822068008b232b3837a9e9
   subdir:
     base-deriving-via
     binary
@@ -132,7 +131,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 877ce057ff6fb086474c8eaad53f2b7f0e0fce6b
+  tag: 6d00ff77f9bcd769fb6d7fd02216cec4e837bfcf
   subdir:
     monoidal-synchronisation
     typed-protocols
@@ -151,7 +150,17 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 808724ff8a19a33d0ed06f9ef59fbd900b08553c
+  -- Important Note: Read below, before changing this!
+  tag: 46f994e216a1f8b36fe4669b47b2a7011b0e153c
+  -- Are you thinking of updating this tag to some other commit?  Please
+  -- ensure that the commit you are about to use is the latest one from
+  -- the *develop* branch of this repo:
+  --   * <https://github.com/input-output-hk/iohk-monitoring-framework/commits/develop>
+  -- (not master!)
+  --
+  -- In particular we rely on the code from this PR:
+  --  * <https://github.com/input-output-hk/iohk-monitoring-framework/pull/622>
+  -- being merged.
   subdir:
     iohk-monitoring
     tracer-transformers
@@ -165,7 +174,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: d5b184a820853c7ba202efd615b8fadca1acb52c
+  tag: 8efcfc755faae4db3a64ad45343235fce3ed5c47
   subdir:
     byron/chain/executable-spec
     byron/crypto
@@ -188,7 +197,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node.git
-  tag: ed11e8b6429d4af1cb2539460e5cb2283a06b2dc
+  tag: 8cf2b208c7708bd890c7e74d5b1d7c4167a3b40b
   subdir:
     cardano-api
     cardano-node

--- a/examples/test/Spec/Game.hs
+++ b/examples/test/Spec/Game.hs
@@ -22,10 +22,6 @@ import           Test.Tasty
 import qualified Test.Tasty.HUnit      as HUnit
 import Prelude
 
-w1, w2 :: Wallet
-w1 = Wallet 1
-w2 = Wallet 2
-
 t1, t2 :: ContractInstanceTag
 t1 = Trace.walletInstanceTag w1
 t2 = Trace.walletInstanceTag w2

--- a/examples/test/Spec/game.pir
+++ b/examples/test/Spec/game.pir
@@ -20,7 +20,8 @@
           StakingPtr
           (fun
             (con integer)
-            (fun (con integer) (fun (con integer) StakingCredential)))
+            (fun (con integer) (fun (con integer) StakingCredential))
+          )
         )
       )
     )
@@ -165,13 +166,16 @@
                     [
                       [
                         (lam
-                          k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ]))
+                          k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ])
+                        )
                         (con bytestring)
                       ]
                       (con integer)
                     ]
                   ]
-                  (fun [ Maybe (con bytestring) ] TxOut)))
+                  (fun [ Maybe (con bytestring) ] TxOut)
+                )
+              )
             )
           )
         )
@@ -198,13 +202,15 @@
                     [
                       [
                         (lam
-                          k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ]))
+                          k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ])
+                        )
                         (con bytestring)
                       ]
                       [
                         [
                           (lam
-                            k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ]))
+                            k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ])
+                          )
                           (con bytestring)
                         ]
                         (con integer)
@@ -214,7 +220,8 @@
                       [
                         [
                           (lam
-                            k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ]))
+                            k (type) (lam v (type) [ List [ [ Tuple2 k ] v ] ])
+                          )
                           (con bytestring)
                         ]
                         [
@@ -222,7 +229,8 @@
                             (lam
                               k
                               (type)
-                              (lam v (type) [ List [ [ Tuple2 k ] v ] ]))
+                              (lam v (type) [ List [ [ Tuple2 k ] v ] ])
+                            )
                             (con bytestring)
                           ]
                           (con integer)
@@ -243,7 +251,16 @@
                                   List
                                   [ [ Tuple2 (con bytestring) ] (con data) ]
                                 ]
-                                (fun (con bytestring) TxInfo))))))))))
+                                (fun (con bytestring) TxInfo)
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
             )
           )
         )
@@ -262,7 +279,8 @@
           (vardecl
             validateGuess
             (fun
-              (con bytestring) (fun (con bytestring) (fun ScriptContext Bool)))
+              (con bytestring) (fun (con bytestring) (fun ScriptContext Bool))
+            )
           )
           (lam
             hs

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -19,19 +19,19 @@ let
     inherit compiler-nix-name;
 
     sha256map = {
-      "https://github.com/input-output-hk/plutus.git"."plutus-starter-devcontainer/v1.0.8" = "0fas8kv57lyrsn3larvbfgif48d506w73y7g3g0mxfilfsl5nyfz";
-      "https://github.com/michaelpj/flat.git"."ee59880f47ab835dbd73bea0847dab7869fc20d8" = "1lrzknw765pz2j97nvv9ip3l1mcpf2zr4n56hwlz0rk7wq7ls4cm";
+      "https://github.com/input-output-hk/plutus.git"."plutus-starter-devcontainer/v1.0.9" = "12mr2p21igzslflr794vh5jhgl5vynrfli09gpjsv0x3g44wq18l";
+      "https://github.com/Quid2/flat.git"."ee59880f47ab835dbd73bea0847dab7869fc20d8" = "1lrzknw765pz2j97nvv9ip3l1mcpf2zr4n56hwlz0rk7wq7ls4cm";
       "https://github.com/shmish111/purescript-bridge.git"."6a92d7853ea514be8b70bab5e72077bf5a510596" = "13j64vv116in3c204qsl1v0ajphac9fqvsjp7x3zzfr7n7g61drb";
       "https://github.com/shmish111/servant-purescript.git"."a76104490499aa72d40c2790d10e9383e0dbde63" = "11nxxmi5bw66va7psvrgrw7b7n85fvqgfp58yva99w3v9q3a50v9";
-      "https://github.com/input-output-hk/cardano-base"."cb0f19c85e5bb5299839ad4ed66af6fa61322cc4" = "0dnkfqcvbifbk3m5pg8kyjqjy0zj1l4vd23p39n6ym4q0bnib1cq";
+      "https://github.com/input-output-hk/cardano-base"."46502694f6a9f0498f822068008b232b3837a9e9" = "04bvsvghkrjhfjb3phh0s5yfb37fishglrrlcwbvcv48y2in1dcz";
       "https://github.com/input-output-hk/cardano-crypto.git"."07397f0e50da97eaa0575d93bee7ac4b2b2576ec" = "06sdx5ndn2g722jhpicmg96vsrys89fl81k8290b3lr6b1b0w4m3";
-      "https://github.com/input-output-hk/cardano-ledger-specs"."d5b184a820853c7ba202efd615b8fadca1acb52c" = "04k5p6qwmfdza65gl5319r1ahdfwjnyqgzpfxdx0x2g5jcbimar4";
+      "https://github.com/input-output-hk/cardano-ledger-specs"."8efcfc755faae4db3a64ad45343235fce3ed5c47" = "13mj8nqk4jglyl96d6zm3dbjmx2qn5gwn06g7cmanxiwfkfm7bi1";
       "https://github.com/input-output-hk/cardano-prelude"."fd773f7a58412131512b9f694ab95653ac430852" = "02jddik1yw0222wd6q0vv10f7y8rdgrlqaiy83ph002f9kjx7mh6";
       "https://github.com/input-output-hk/goblins"."cde90a2b27f79187ca8310b6549331e59595e7ba" = "17c88rbva3iw82yg9srlxjv2ia5wjb9cyqw44hik565f5v9svnyg";
-      "https://github.com/input-output-hk/iohk-monitoring-framework"."808724ff8a19a33d0ed06f9ef59fbd900b08553c" = "0298dpl29gxzs9as9ha6y0w18hqwc00ipa3hzkxv7nlfrjjz8hmz";
+      "https://github.com/input-output-hk/iohk-monitoring-framework"."46f994e216a1f8b36fe4669b47b2a7011b0e153c" = "1il8fx3misp3650ryj368b3x95ksz01zz3x0z9k00807j93d0ka0";
       "https://github.com/input-output-hk/optparse-applicative"."7497a29cb998721a9068d5725d49461f2bba0e7a" = "1gvsrg925vynwgqwplgjmp53vj953qyh3wbdf34pw21c8r47w35r";
-      "https://github.com/input-output-hk/ouroboros-network"."877ce057ff6fb086474c8eaad53f2b7f0e0fce6b" = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
-      "https://github.com/input-output-hk/cardano-node.git"."ed11e8b6429d4af1cb2539460e5cb2283a06b2dc" = "1wvr3zzl37i1fn5y9ni027rqw5bhh25z1bacvcaapxxjgdn38lbq";
+      "https://github.com/input-output-hk/ouroboros-network"."6d00ff77f9bcd769fb6d7fd02216cec4e837bfcf" = "19dfhm9r1z00jqwpbnx7z0d58gpqsbwx4p96xlwwamd40hi3asn3";
+      "https://github.com/input-output-hk/cardano-node.git"."8cf2b208c7708bd890c7e74d5b1d7c4167a3b40b" = "0akmzzf1gb8067knlzpbqdpkn3zrk5fm16icdzip44ilzwl5y2m0";
       "https://github.com/input-output-hk/Win32-network"."3825d3abf75f83f406c1f7161883c438dac7277d" = "19wahfv726fa3mqajpqdqhnl9ica3xmf68i254q45iyjcpj1psqx";
       "https://github.com/input-output-hk/hedgehog-extras"."edf6945007177a638fbeb8802397f3a6f4e47c14" = "0wc7qzkc7j4ns2rz562h6qrx2f8xyq7yjcb7zidnj7f6j0pcd0i9";
     };


### PR DESCRIPTION
Adds a function to demonstrate computing the script costings for a given trace, inspired by [some new documentation](https://github.com/input-output-hk/plutus/pull/3894#pullrequestreview-750161067).

TODO:

- [x] Fix up the API calls in the readme to use the right wallet constructor