### PR TITLE
Track plutus apps

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2021-08-14T00:00:00Z
+index-state: 2022-01-22T00:00:00Z
 
 packages: ./.
 
@@ -9,20 +9,27 @@ write-ghc-environment-files: never
 tests: true
 benchmarks: true
 
--- Plutus revision from 2021/08/16
+-- Plutus apps revision from 2022/03/10
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus-apps.git
   subdir:
+    doc
     freer-extras
     playground-common
-    plutus-contract
     plutus-chain-index
+    plutus-chain-index-core
+    plutus-contract
+    plutus-example
     plutus-ledger
+    plutus-ledger-constraints
     plutus-pab
+    plutus-pab-executables
+    plutus-playground-server
     plutus-use-cases
     quickcheck-dynamic
-  tag: plutus-starter-devcontainer/v1.0.14
+    web-ghc
+  tag: 4c60896dff0c31a98395ba6e6791433cd61a25e3
 
 
 -- The following sections are copied from the 'plutus-apps' repository cabal.project at the revision
@@ -38,26 +45,11 @@ write-ghc-environment-files: never
 tests: true
 benchmarks: true
 
--- The only sensible test display option
+-- The only sensible test display option.
 test-show-details: streaming
 
 allow-newer:
-           -- Copied from plutus-core
            size-based:template-haskell
-           , ouroboros-consensus-byron:formatting
-           , beam-core:aeson
-           , beam-sqlite:aeson
-           , beam-sqlite:dlist
-           , beam-migrate:aeson
-
--- Copied from plutus-core
-constraints:
-  -- big breaking change here, inline-r doens't have an upper bound
-  singletons < 3.0
-  -- bizarre issue: in earlier versions they define their own 'GEq', in newer
-  -- ones they reuse the one from 'some', but there isn't e.g. a proper version
-  -- constraint from dependent-sum-template (which is the library we actually use).
-  , dependent-sum > 0.6.2.0
 
 -- These packages appear in our dependency tree and are very slow to build.
 -- Empirically, turning off optimization shaves off ~50% build time.
@@ -71,179 +63,223 @@ package ouroboros-consensus-cardano
   optimization: False
 package cardano-api
   optimization: False
+package cardano-wallet
+  optimization: False
+package cardano-wallet-core
+  optimization: False
+package cardano-wallet-cli
+  optimization: False
+package cardano-wallet-launcher
+  optimization: False
+package cardano-wallet-core-integration
+  optimization: False
 
--- Copied from plutus-core
+-- Direct dependency.
+-- Are you thinking of updating this tag to some other commit?
+-- Please ensure that the commit you are about to use is the latest one from
+-- the *develop* branch of this repo:
+--   * <https://github.com/input-output-hk/iohk-monitoring-framework/commits/develop>
+-- (not master!)
+--
+-- In particular we rely on the code from this PR:
+--  * <https://github.com/input-output-hk/iohk-monitoring-framework/pull/622>
+-- being merged.
 source-repository-package
   type: git
-  location: https://github.com/Quid2/flat.git
+  location: https://github.com/input-output-hk/iohk-monitoring-framework
+  tag: 46f994e216a1f8b36fe4669b47b2a7011b0e153c
+  subdir:
+    contra-tracer
+    iohk-monitoring
+    tracer-transformers
+    plugins/backend-ekg
+    plugins/backend-aggregation
+    plugins/backend-monitoring
+    plugins/backend-trace-forwarder
+
+-- Direct dependency.
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/plutus
+  tag: 4127e9cd6e889824d724c30eae55033cb50cbf3e
+  subdir:
+    plutus-core
+    plutus-ledger-api
+    plutus-tx
+    plutus-tx-plugin
+    prettyprinter-configurable
+    stubs/plutus-ghc-stub
+    word-array
+
+-- Should follow plutus.
+source-repository-package
+  type: git
+  location: https://github.com/Quid2/flat
   tag: ee59880f47ab835dbd73bea0847dab7869fc20d8
 
--- Needs some patches, but upstream seems to be fairly dead (no activity in > 1 year)
+-- Direct dependency.
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/purescript-bridge.git
-  tag: 6a92d7853ea514be8b70bab5e72077bf5a510596
+  location: https://github.com/input-output-hk/servant-purescript
+  tag: 44e7cacf109f84984cd99cd3faf185d161826963
+
+-- Direct dependency.
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/purescript-bridge
+  tag: 47a1f11825a0f9445e0f98792f79172efef66c00
+
+-- Direct dependency.
+-- Compared to others, cardano-wallet doesn't bump dependencies very often.
+-- Making it a good place to start when bumping dependencies.
+-- As, for example, bumping the node first highly risks breaking API with the wallet.
+-- Unless early bug fixes are required, this is fine as the wallet tracks stable releases of the node.
+-- And it is indeed nice for plutus-apps to track stable releases of the node too.
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-wallet
+  tag: a5085acbd2670c24251cf8d76a4e83c77a2679ba
+  subdir:
+    lib/cli
+    lib/core
+    lib/core-integration
+    lib/dbvar
+    lib/launcher
+    lib/numeric
+    lib/shelley
+    lib/strict-non-empty-containers
+    lib/test-utils
+    lib/text-class
+
+-- Should follow cardano-wallet.
+-- Currently tracking v1.33.0.
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-node
+  tag: 814df2c146f5d56f8c35a681fe75e85b905aed5d
+  subdir:
+    cardano-api
+    cardano-cli
+    cardano-node
+    cardano-testnet
 
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/servant-purescript.git
-  tag: a0c7c7e37c95564061247461aef4be505a853538
+  location: https://github.com/input-output-hk/cardano-config
+  tag: e9de7a2cf70796f6ff26eac9f9540184ded0e4e6
+  --sha256: 1wm1c99r5zvz22pdl8nhkp13falvqmj8dgkm8fxskwa9ydqz01ld
 
--- Copied from plutus-core
+-- Using a fork until our patches can be merged upstream
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/cardano-crypto.git
-  tag: 07397f0e50da97eaa0575d93bee7ac4b2b2576ec
+  location: https://github.com/input-output-hk/optparse-applicative
+  tag: 7497a29cb998721a9068d5725d49461f2bba0e7a
+  --sha256: 1gvsrg925vynwgqwplgjmp53vj953qyh3wbdf34pw21c8r47w35r
 
--- Copied from plutus-core
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/hedgehog-extras
+  tag: edf6945007177a638fbeb8802397f3a6f4e47c14
+  --sha256: 0wc7qzkc7j4ns2rz562h6qrx2f8xyq7yjcb7zidnj7f6j0pcd0i9
+
+-- Should follow cardano-wallet.
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger
+  tag: 1a9ec4ae9e0b09d54e49b2a40c4ead37edadcce5
+  subdir:
+    eras/alonzo/impl
+    eras/byron/chain/executable-spec
+    eras/byron/crypto
+    eras/byron/crypto/test
+    eras/byron/ledger/executable-spec
+    eras/byron/ledger/impl
+    eras/byron/ledger/impl/test
+    eras/shelley/impl
+    eras/shelley/test-suite
+    eras/shelley-ma/impl
+    libs/cardano-data
+    libs/cardano-ledger-core
+    libs/cardano-ledger-pretty
+    libs/cardano-protocol-tpraos
+    libs/compact-map
+    libs/non-integral
+    libs/set-algebra
+    libs/small-steps
+    libs/small-steps-test
+
+-- Should follow cardano-wallet.
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-network
+  tag: d2d219a86cda42787325bb8c20539a75c2667132
+  subdir:
+    io-classes
+    io-sim
+    monoidal-synchronisation
+    network-mux
+    ntp-client
+    ouroboros-consensus
+    ouroboros-consensus-byron
+    ouroboros-consensus-cardano
+    ouroboros-consensus-protocol
+    ouroboros-consensus-shelley
+    ouroboros-network
+    ouroboros-network-framework
+    ouroboros-network-testing
+    strict-stm
+    typed-protocols
+    typed-protocols-cborg
+    typed-protocols-examples
+
+-- Should follow cardano-wallet.
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 4ea7e2d927c9a7f78ddc69738409a5827ab66b98
+  tag: 41545ba3ac6b3095966316a99883d678b5ab8da8
   subdir:
     base-deriving-via
     binary
     binary/test
     cardano-crypto-class
     cardano-crypto-praos
-    cardano-crypto-tests
     measures
     orphans-deriving-via
     slotting
     strict-containers
 
--- Copied from plutus-core
+-- Should follow cardano-wallet.
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: fd773f7a58412131512b9f694ab95653ac430852
+  tag: bb4ed71ba8e587f672d06edf9d2e376f4b055555
   subdir:
     cardano-prelude
     cardano-prelude-test
 
+-- Should follow cardano-wallet.
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-crypto
+  tag: f73079303f663e028288f9f4a9e08bcca39a923e
+
+-- Should follow cardano-wallet.
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-addresses
-  tag: d2f86caa085402a953920c6714a0de6a50b655ec
+  tag: 71006f9eb956b0004022e80aadd4ad50d837b621
   subdir:
+    command-line
     core
 
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-wallet
-  tag: ae7569293e94241ef6829139ec02bd91abd069df
-  subdir:
-    lib/text-class
-    lib/strict-non-empty-containers
-    lib/core
-    lib/test-utils
-    lib/numeric
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 1f4973f36f689d6da75b5d351fb124d66ef1057d
-  subdir:
-    monoidal-synchronisation
-    typed-protocols
-    typed-protocols-cborg
-    typed-protocols-examples
-    ouroboros-network
-    ouroboros-network-testing
-    ouroboros-network-framework
-    ouroboros-consensus
-    ouroboros-consensus-byron
-    ouroboros-consensus-cardano
-    ouroboros-consensus-shelley
-    io-sim
-    io-classes
-    network-mux
-    ntp-client
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/iohk-monitoring-framework
-  -- Important Note: Read below, before changing this!
-  tag: 46f994e216a1f8b36fe4669b47b2a7011b0e153c
-  -- Are you thinking of updating this tag to some other commit?  Please
-  -- ensure that the commit you are about to use is the latest one from
-  -- the *develop* branch of this repo:
-  --   * <https://github.com/input-output-hk/iohk-monitoring-framework/commits/develop>
-  -- (not master!)
-  --
-  -- In particular we rely on the code from this PR:
-  --  * <https://github.com/input-output-hk/iohk-monitoring-framework/pull/622>
-  -- being merged.
-  subdir:
-    iohk-monitoring
-    tracer-transformers
-    contra-tracer
-    plugins/backend-aggregation
-    plugins/backend-ekg
-    plugins/backend-monitoring
-    plugins/backend-trace-forwarder
-    plugins/scribe-systemd
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: bf008ce028751cae9fb0b53c3bef20f07c06e333
-  subdir:
-    byron/ledger/impl
-    cardano-ledger-core
-    cardano-protocol-tpraos
-    eras/alonzo/impl
-    eras/byron/chain/executable-spec
-    eras/byron/crypto
-    eras/byron/crypto/test
-    eras/byron/ledger/executable-spec
-    eras/byron/ledger/impl/test
-    eras/shelley/impl
-    eras/shelley-ma/impl
-    libs/non-integral
-    libs/small-steps
-    semantics/small-steps-test
-
--- A lot of plutus-apps dependencies have to be synchronized with the dependencies of
--- cardano-node. If you update cardano-node, please make sure that all dependencies
--- of cardano-node are also updated.
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-node.git
-  tag: b6ca519f97a0e795611a63174687e6bb70c9f752
-  subdir:
-    cardano-api
-    cardano-node
-    cardano-cli
-    cardano-config
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/optparse-applicative
-  tag: 7497a29cb998721a9068d5725d49461f2bba0e7a
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/Win32-network
-  tag: 3825d3abf75f83f406c1f7161883c438dac7277d
-
+-- Should follow cardano-wallet.
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/goblins
   tag: cde90a2b27f79187ca8310b6549331e59595e7ba
 
--- A lot of plutus-apps dependencies have to be syncronized with the dependencies of
--- plutus. If you update plutus, please make sure that all dependencies of plutus
--- are also updated
+-- Should follow cardano-wallet.
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/plutus
-  tag: 3f089ccf0ca746b399c99afe51e063b0640af547
-  subdir:
-    plutus-core
-    plutus-ledger-api
-    plutus-tx
-    plutus-tx-plugin
-    word-array
-    prettyprinter-configurable
-    stubs/plutus-ghc-stub
+  location: https://github.com/input-output-hk/Win32-network
+  tag: 3825d3abf75f83f406c1f7161883c438dac7277d

--- a/plutus-starter.cabal
+++ b/plutus-starter.cabal
@@ -51,9 +51,10 @@ library
       freer-extras,
       playground-common,
       plutus-contract,
-      plutus-tx-plugin,
-      plutus-tx,
       plutus-ledger,
+      plutus-ledger-constraints,
+      plutus-tx,
+      plutus-tx-plugin,
     hs-source-dirs: src examples/src
 
 test-suite plutus-example-projects-test


### PR DESCRIPTION
Plutus starter is quite behind plutus-apps currently. This prevents making use of latest changes in Plutus. 
This PR updates dependencies to track the latest commit as of createing this PR - commit hash: `4c60896dff0c31a98395ba6e6791433cd61a25e3`

The latest release for plutus-apps is dated 2022-01-17, which is quite a while ago. So, I picked latest commit of plutus-apps for updating dependencies.

Tests done:
Build works fine (in a nix-shell in local env) . 
Ran test cases for a contract using emulatorTrace. Works fine.