### PR TITLE
Update devcontainer to latest version 1.0.15

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Plutus Starter Project",
-    "image": "docker.io/inputoutput/plutus-starter-devcontainer:v0.1.0",
+    "image": "docker.io/inputoutput/plutus-starter-devcontainer:v1.0.15",
 
     "remoteUser": "plutus",
 


### PR DESCRIPTION
Hi @koslambrou, the lastest version of devcontainer should be `v1.0.15`, the link is the reference

https://hub.docker.com/r/inputoutput/plutus-starter-devcontainer/tags

This one is the image https://hub.docker.com/layers/plutus-starter-devcontainer/inputoutput/plutus-starter-devcontainer/v1.0.15/images/sha256-67465ea489e8d4622b7e0641e5026e2a1c8f9e0f2606ec68b1b8c89979c93bc4?context=explore