### PR TITLE
Move test into matrix to reuse code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,13 @@ on:
     branches:
       - main
 jobs:
-  nix-build:
+  tests:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        test:
+          - ./scripts/test
+          - nix-build release.nix --restrict-eval -I . -A required --no-out-link
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.3.4
@@ -18,19 +21,4 @@ jobs:
             allowed-uris = https://github.com/NixOS/nixpkgs https://github.com/input-output-hk https://github.com/NixOS/nixpkgs-channels
             trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://hydra.iohk.io https://iohk.cachix.org https://cache.nixos.org/
-      - run: nix-build release.nix --restrict-eval -I . -A required --no-out-link
-
-  guessing-game:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: nixbuild/nix-quick-install-action@v9
-        with:
-          nix_conf: |
-            allowed-uris = https://github.com/NixOS/nixpkgs https://github.com/input-output-hk https://github.com/NixOS/nixpkgs-channels
-            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-            substituters = https://hydra.iohk.io https://iohk.cachix.org https://cache.nixos.org/
-      - run: ./scripts/test
+      - run: ${{ matrix.test }}


### PR DESCRIPTION
This piece of code is the same, we could reuse it in tests
```yaml
    strategy:
      matrix:
        os: [ubuntu-latest]
    runs-on: ${{ matrix.os }}
    steps:
      - uses: actions/checkout@v2.3.4
      - uses: nixbuild/nix-quick-install-action@v9
        with:
          nix_conf: |
            allowed-uris = https://github.com/NixOS/nixpkgs https://github.com/input-output-hk https://github.com/NixOS/nixpkgs-channels
            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
            substituters = https://hydra.iohk.io https://iohk.cachix.org https://cache.nixos.org/
```